### PR TITLE
Create Endpoint: GET Favorites by ID

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -14,6 +14,13 @@ router.get('/', (request, response) => {
     })
 });
 
+router.get('/:id', (request, response) => {
+  favoriteSong(request.params.id)
+    .then(favorite => {
+      response.status(200).send(favorite)
+    })
+});
+
 router.post('/', (request, response) => {
   var body = request.body;
 
@@ -50,6 +57,12 @@ async function favoriteSongs() {
   }
 }
 
-
+async function favoriteSong(songId) {
+  try{
+    return await database('favorites').where({id: songId});
+  }catch(e){
+    return e;
+  }
+}
 
 module.exports = router;

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -10,15 +10,27 @@ const Favorite = require("../../../models/favorite");
 router.get('/', (request, response) => {
   favoriteSongs()
     .then(favorites => {
+      if (favorites.length){
       response.status(200).send(favorites)
+    } else {
+      response.status(404).json({
+        error: 'Record not found.'
+      })
+    }
     })
 });
 
 router.get('/:id', (request, response) => {
   favoriteSong(request.params.id)
     .then(favorite => {
+      if (favorite.length){
       response.status(200).send(favorite)
-    })
+    } else {
+      response.status(404).json({
+        error: 'Not found.'
+      })
+    }
+  })
 });
 
 router.post('/', (request, response) => {
@@ -52,6 +64,7 @@ router.post('/', (request, response) => {
 async function favoriteSongs() {
   try{
     return await database('favorites')
+    .column(['id', 'title', 'artist_name', 'genre', 'rating'])
   }catch(e){
     return e;
   }
@@ -59,7 +72,8 @@ async function favoriteSongs() {
 
 async function favoriteSong(songId) {
   try{
-    return await database('favorites').where({id: songId});
+    return await database('favorites').where({id: songId})
+    .column(['id', 'title', 'artist_name', 'genre', 'rating'])
   }catch(e){
     return e;
   }

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -14,7 +14,7 @@ router.get('/', (request, response) => {
       response.status(200).send(favorites)
     } else {
       response.status(404).json({
-        error: 'Record not found.'
+        error: 'Not found.'
       })
     }
     })
@@ -27,7 +27,7 @@ router.get('/:id', (request, response) => {
       response.status(200).send(favorite)
     } else {
       response.status(404).json({
-        error: 'Not found.'
+        error: 'Record not found.'
       })
     }
   })

--- a/tests/favorites/index.spec.js
+++ b/tests/favorites/index.spec.js
@@ -17,17 +17,18 @@ describe("Test GET favorites", () => {
     await database.raw("TRUNCATE TABLE favorites CASCADE");
   });
 
-  it.skip("returns a list of all favorites in the db", async () => {
-    let fave_1 = new Favorite({id: 1, title: 'Thunderstruck', artistName: 'AC/DC', genre: 'Rock', rating: 98})
+  it("returns a list of all favorites in the db", async () => {
+    let fave1 = await database('favorites')
+      .insert({id: 1, title: 'Thunderstruck', artist_name: 'AC/DC', genre: 'Rock', rating: 98})
+      .returning(['id', 'title', 'artist_name', 'genre', 'rating'])
 
-    let fave_2 = new Favorite({id: 2, title: 'Africa', artistName: 'Toto', genre: 'pop', rating: 100})
-
-    await database('favorites').insert(fave_1)
-    await database('favorites').insert(fave_2)
+    let fave2 = await database('favorites')
+      .insert({id: 2, title: 'Africa', artist_name: 'Toto', genre: 'pop', rating: 100})
+      .returning(['id', 'title', 'artist_name', 'genre', 'rating'])
 
     var response = await request(app)
     .get('/api/v1/favorites')
       expect(response.status).toBe(200)
-      expect(Object(response.body)).toMatchObject([fave_1, fave_2])
+      expect(response.body).toMatchObject([fave1[0], fave2[0]])
   });
 });

--- a/tests/favorites/show.spec.js
+++ b/tests/favorites/show.spec.js
@@ -1,0 +1,39 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../../knexfile')[environment];
+const database = require('knex')(configuration);
+const Favorite = require("../../models/favorite");
+
+describe("Test GET favorites/:id", () => {
+  beforeEach(async () => {
+    await database.raw("TRUNCATE TABLE favorites CASCADE");
+  });
+
+  afterEach(async () => {
+    await database.raw("TRUNCATE TABLE favorites CASCADE");
+  });
+
+  it("returns a single favorite by id", async () => {
+
+    await database('favorites').insert({id: 1, title: 'Thunderstruck', artist_name: 'AC/DC', genre: 'Rock', rating: 98})
+
+    await database('favorites').insert({id: 2, title: 'Africa', artist_name: 'Toto', genre: 'pop', rating: 100})
+
+    var response = await request(app)
+    .get('/api/v1/favorites/1')
+
+    expect(response.status).toBe(200)
+    expect(response.body[0].artist_name).toBe('AC/DC')
+    expect(response.body[0].title).toBe('Thunderstruck')
+
+    var response = await request(app)
+    .get('/api/v1/favorites/2')
+
+    expect(response.status).toBe(200)
+    expect(response.body[0].artist_name).toBe('Toto')
+    expect(response.body[0].title).toBe('Africa')
+  });
+});

--- a/tests/favorites/show.spec.js
+++ b/tests/favorites/show.spec.js
@@ -36,4 +36,13 @@ describe("Test GET favorites/:id", () => {
     expect(response.body[0].artist_name).toBe('Toto')
     expect(response.body[0].title).toBe('Africa')
   });
+
+  it("returns a 404 if id is not found", async () => {
+
+    var response = await request(app)
+    .get('/api/v1/favorites/1')
+
+    expect(response.status).toBe(404)
+    expect(response.body.error).toBe('Record not found.')
+  });
 });


### PR DESCRIPTION
This PR does the following: 
- Adds `/api/v1/favorites/:id` route 
- Adds sad path and 404 message if record is not found 
- Updates `/api/v1/favorites` to have sad path 404 message 