### PR TITLE
POST favorites and GET ...favorites/:id for staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 coverage
 node_modules
-
+.env

--- a/knexfile.js
+++ b/knexfile.js
@@ -21,6 +21,14 @@ module.exports = {
     },
     useNullAsDefault: true
   },
+  staging: {
+    client: 'pg',
+    connection: 'postgres://fmmgjuscqdudrf:54651ac2fb92f4c81dbde7ac060e7550469c6eb92ad5af5ae41a68d562b70555@ec2-174-129-255-46.compute-1.amazonaws.com:5432/dchle8rhf9bbqg',
+    migrations: {
+      directory: './db/migrations'
+    },
+    useNullAsDefault: true
+  },
   production: {
     client: 'pg',
     connection: 'postgres://mtzrtdvtipcjwx:a205bc768c4d0c9c35860bf5280f62ab0e899ae9469f24e6df9850717e608c68@ec2-174-129-253-86.compute-1.amazonaws.com:5432/d8qj2c75qm2ra3',

--- a/models/favorite.js
+++ b/models/favorite.js
@@ -1,9 +1,19 @@
 class Favorite {
   constructor(obj) {
-    this.title = obj.title,
-    this.artist_name = obj.artistName,
-    this.genre = obj.genre || 'Unknown',
-    this.rating = obj.rating
+    this.title = obj.message.body.track.track_name,
+    this.artist_name = obj.message.body.track.artist_name,
+    this.genre = this.getGenre(obj),
+    this.rating = obj.message.body.track.track_rating
+  }
+
+  getGenre(obj) {
+    let genreObject = obj.message.body.track.primary_genres.music_genre_list[0];
+
+    if (genreObject) {
+      return genreObject.music_genre.music_genre_name;
+    } else {
+      return 'Unknown';
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1266,6 +1266,11 @@
         "webidl-conversions": "^4.0.2"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -3796,6 +3801,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   "dependencies": {
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
+    "dotenv": "^8.2.0",
     "express": "~4.16.1",
-    "morgan": "~1.9.1",
     "knex": ">=0.19.5",
+    "morgan": "~1.9.1",
+    "node-fetch": "^2.6.0",
     "pg": "^7.8.0"
   },
   "devDependencies": {

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -1,42 +1,54 @@
+require('dotenv').config()
 var express = require('express');
 var router = express.Router();
-
 const environment = process.env.NODE_ENV || 'development';
 const configuration = require('../../../knexfile')[environment];
 const database = require('knex')(configuration);
 const Favorite = require("../../../models/favorite");
-
+const MusixService = require("../../../services/musixService");
 
 router.get('/', (request, response) => {
-  
+  favoriteSongs()
+    .then(favorites => {
+      response.status(200).send(favorites)
+    })
 });
 
 router.post('/', (request, response) => {
   var body = request.body;
-  
-  for (let requiredParam of ['title', 'artistName', 'rating']) {
+  const title = body.title;
+  const artist = body.artistName;
+
+  for (let requiredParam of ['title', 'artistName']) {
     if (!body[requiredParam]) {
       return response
       .status(400)
       .send({ error: `Missing required attribute <${requiredParam}>` });
     }
   }
-  
-  var rating = parseInt(request.body.rating)
-  
-  if (!(rating >= 1 && rating <= 100)) {
-    return response
-      .status(400)
-      .send({ error: "Rating must be between 1-100" })
-  }
 
-  var fav = new Favorite(body);
+  const service = new MusixService(title, artist);
 
-  database('favorites')
-    .insert(fav, 'id')
-    .returning('id')
-    .then(id => response.status(201).send({ id: id[0] }))
-    .catch(error => response.status(500).send({ error }))
+  service.fetchSongInfo(title, artist)
+  .then(res => {
+    var fav = new Favorite(res);
+
+    database('favorites')
+      .insert(fav, 'id')
+      .returning(['id', 'title', 'artist_name', 'genre', 'rating'])
+      .then(attr => {
+        response.status(201).send(attr[0])
+      })
+      .catch(error => response.status(500).send({ error }))
+  })
 });
+
+async function favoriteSongs() {
+  try{
+    return await database('favorites')
+  }catch(e){
+    return e;
+  }
+}
 
 module.exports = router;

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -10,8 +10,27 @@ const MusixService = require("../../../services/musixService");
 router.get('/', (request, response) => {
   favoriteSongs()
     .then(favorites => {
+      if (favorites.length){
       response.status(200).send(favorites)
+    } else {
+      response.status(404).json({
+        error: 'Not found.'
+      })
+    }
     })
+});
+
+router.get('/:id', (request, response) => {
+  favoriteSong(request.params.id)
+    .then(favorite => {
+      if (favorite.length){
+      response.status(200).send(favorite)
+    } else {
+      response.status(404).json({
+        error: 'Record not found.'
+      })
+    }
+  })
 });
 
 router.post('/', (request, response) => {
@@ -46,6 +65,16 @@ router.post('/', (request, response) => {
 async function favoriteSongs() {
   try{
     return await database('favorites')
+    .column(['id', 'title', 'artist_name', 'genre', 'rating'])
+  }catch(e){
+    return e;
+  }
+}
+
+async function favoriteSong(songId) {
+  try{
+    return await database('favorites').where({id: songId})
+    .column(['id', 'title', 'artist_name', 'genre', 'rating'])
   }catch(e){
     return e;
   }

--- a/services/musixService.js
+++ b/services/musixService.js
@@ -1,0 +1,23 @@
+const fetch = require('node-fetch');
+
+class MusixService {
+  constructor(title, artist) {
+    this.key = process.env.MUSIXMATCH_KEY,
+    this.url = `https://api.musixmatch.com/ws/1.1/matcher.track.get` +
+      `?q_track=${title}` +
+      `&q_artist=${artist}` +
+      `&apikey=${this.key}`
+  }
+
+  async fetchSongInfo() {
+    try {
+      let res = await fetch(this.url);
+      let json = await res.json();
+      return json;
+    } catch(e) {
+      return e;
+    }
+  }
+}
+
+module.exports = MusixService;

--- a/tests/favorites/create.spec.js
+++ b/tests/favorites/create.spec.js
@@ -17,11 +17,8 @@ describe("Test POST to favorites", () => {
 
   it("happy path", async () => {
     const body = {
-      "id": 1,
       "title": "We Will Rock You",
-      "artistName": "Queen",
-      "genre": "Rock",
-      "rating": 88
+      "artistName": "Queen"
     };
 
     const noFavs = await database('favorites').first()
@@ -33,20 +30,22 @@ describe("Test POST to favorites", () => {
 
     expect(res.statusCode).toBe(201);
     expect(res.body).toHaveProperty('id');
+    expect(res.body).toHaveProperty('title');
+    expect(res.body).toHaveProperty('artist_name');
+    expect(res.body).toHaveProperty('genre');
+    expect(res.body).toHaveProperty('rating');
 
     const fav = await database('favorites').first();
-    expect(fav.title).toBe(body.title);
-    expect(fav.artist_name).toBe(body.artistName);
-    expect(fav.genre).toBe(body.genre);
-    expect(fav.rating).toBe(body.rating);
+    expect(fav.title).toBe("We Will Rock You");
+    expect(fav.artist_name).toBe("Queen");
+    expect(fav.genre).toBe("Arena Rock");
+    expect(fav.rating).toBe(79);
   })
 
   it("happy path with default genre", async ()=> {
     const body = {
-      "id": 1,
-      "title": "We Will Rock You",
-      "artistName": "Queen",
-      "rating": 88
+      "title": "Under Pressure",
+      "artistName": "Vanilla Ice vs. Queen Bowie"
     };
 
     const res = await request(app)
@@ -62,10 +61,7 @@ describe("Test POST to favorites", () => {
   it("sad path: missing required attribute", async ()=> {
     // Missing <title>
     var body = {
-      "id": 1,
       "artistName": "Queen",
-      "genre": "Rock",
-      "rating": 88
     };
 
     var res = await request(app)
@@ -77,10 +73,7 @@ describe("Test POST to favorites", () => {
 
     // Missing <artistName>
     var body = {
-      "id": 1,
-      "title": "We Will Rock You",
-      "genre": "Rock",
-      "rating": 88
+      "title": "We Will Rock You"
     };
 
     var res = await request(app)
@@ -89,70 +82,5 @@ describe("Test POST to favorites", () => {
 
     expect(res.statusCode).toBe(400)
     expect(res.body).toMatchObject({ error: 'Missing required attribute <artistName>' })
-
-    // Missing <rating>
-    var body = {
-      "id": 1,
-      "title": "We Will Rock You",
-      "artistName": "Queen",
-      "genre": "Rock",
-    };
-
-    var res = await request(app)
-      .post("/api/v1/favorites")
-      .send(body);
-
-    expect(res.statusCode).toBe(400)
-    expect(res.body).toMatchObject({ error: 'Missing required attribute <rating>' })
-  })
-
-  it("sad path: rating not in range 1-100", async ()=> {
-    // rating < 1
-    var body = {
-      "id": 1,
-      "title": "We Will Rock You",
-      "artistName": "Queen",
-      "genre": "Rock",
-      "rating": -5
-    };
-
-    var res = await request(app)
-      .post("/api/v1/favorites")
-      .send(body);
-
-    expect(res.statusCode).toBe(400)
-    expect(res.body).toMatchObject({ error: "Rating must be between 1-100" })
-
-    // rating > 100
-    var body = {
-      "id": 1,
-      "title": "We Will Rock You",
-      "artistName": "Queen",
-      "genre": "Rock",
-      "rating": 230
-    };
-
-    var res = await request(app)
-      .post("/api/v1/favorites")
-      .send(body);
-
-    expect(res.statusCode).toBe(400)
-    expect(res.body).toMatchObject({ error: "Rating must be between 1-100" })
-
-    // rating is NaN
-    var body = {
-      "id": 1,
-      "title": "We Will Rock You",
-      "artistName": "Queen",
-      "genre": "Rock",
-      "rating": 'askjdf'
-    };
-
-    var res = await request(app)
-      .post("/api/v1/favorites")
-      .send(body);
-
-    expect(res.statusCode).toBe(400)
-    expect(res.body).toMatchObject({ error: "Rating must be between 1-100" })
   })
 })

--- a/tests/favorites/index.spec.js
+++ b/tests/favorites/index.spec.js
@@ -1,0 +1,33 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../../knexfile')[environment];
+const database = require('knex')(configuration);
+const Favorite = require("../../models/favorite");
+
+
+describe("Test GET favorites", () => {
+  beforeEach(async () => {
+    await database.raw("TRUNCATE TABLE favorites CASCADE");
+  });
+
+  afterEach(async () => {
+    await database.raw("TRUNCATE TABLE favorites CASCADE");
+  });
+
+  it.skip("returns a list of all favorites in the db", async () => {
+    let fave_1 = new Favorite({id: 1, title: 'Thunderstruck', artistName: 'AC/DC', genre: 'Rock', rating: 98})
+
+    let fave_2 = new Favorite({id: 2, title: 'Africa', artistName: 'Toto', genre: 'pop', rating: 100})
+
+    await database('favorites').insert(fave_1)
+    await database('favorites').insert(fave_2)
+
+    var response = await request(app)
+    .get('/api/v1/favorites')
+      expect(response.status).toBe(200)
+      expect(Object(response.body)).toMatchObject([fave_1, fave_2])
+  });
+});

--- a/tests/favorites/index.spec.js
+++ b/tests/favorites/index.spec.js
@@ -17,17 +17,18 @@ describe("Test GET favorites", () => {
     await database.raw("TRUNCATE TABLE favorites CASCADE");
   });
 
-  it.skip("returns a list of all favorites in the db", async () => {
-    let fave_1 = new Favorite({id: 1, title: 'Thunderstruck', artistName: 'AC/DC', genre: 'Rock', rating: 98})
+  it("returns a list of all favorites in the db", async () => {
+    let fave1 = await database('favorites')
+      .insert({id: 1, title: 'Thunderstruck', artist_name: 'AC/DC', genre: 'Rock', rating: 98})
+      .returning(['id', 'title', 'artist_name', 'genre', 'rating'])
 
-    let fave_2 = new Favorite({id: 2, title: 'Africa', artistName: 'Toto', genre: 'pop', rating: 100})
-
-    await database('favorites').insert(fave_1)
-    await database('favorites').insert(fave_2)
+    let fave2 = await database('favorites')
+      .insert({id: 2, title: 'Africa', artist_name: 'Toto', genre: 'pop', rating: 100})
+      .returning(['id', 'title', 'artist_name', 'genre', 'rating'])
 
     var response = await request(app)
     .get('/api/v1/favorites')
       expect(response.status).toBe(200)
-      expect(Object(response.body)).toMatchObject([fave_1, fave_2])
+      expect(response.body).toMatchObject([fave1[0], fave2[0]])
   });
 });

--- a/tests/favorites/show.spec.js
+++ b/tests/favorites/show.spec.js
@@ -1,0 +1,48 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../../knexfile')[environment];
+const database = require('knex')(configuration);
+const Favorite = require("../../models/favorite");
+
+describe("Test GET favorites/:id", () => {
+  beforeEach(async () => {
+    await database.raw("TRUNCATE TABLE favorites CASCADE");
+  });
+
+  afterEach(async () => {
+    await database.raw("TRUNCATE TABLE favorites CASCADE");
+  });
+
+  it("returns a single favorite by id", async () => {
+
+    await database('favorites').insert({id: 1, title: 'Thunderstruck', artist_name: 'AC/DC', genre: 'Rock', rating: 98})
+
+    await database('favorites').insert({id: 2, title: 'Africa', artist_name: 'Toto', genre: 'pop', rating: 100})
+
+    var response = await request(app)
+    .get('/api/v1/favorites/1')
+
+    expect(response.status).toBe(200)
+    expect(response.body[0].artist_name).toBe('AC/DC')
+    expect(response.body[0].title).toBe('Thunderstruck')
+
+    var response = await request(app)
+    .get('/api/v1/favorites/2')
+
+    expect(response.status).toBe(200)
+    expect(response.body[0].artist_name).toBe('Toto')
+    expect(response.body[0].title).toBe('Africa')
+  });
+
+  it("returns a 404 if id is not found", async () => {
+
+    var response = await request(app)
+    .get('/api/v1/favorites/1')
+
+    expect(response.status).toBe(404)
+    expect(response.body.error).toBe('Record not found.')
+  });
+});

--- a/tests/models/favorite.spec.js
+++ b/tests/models/favorite.spec.js
@@ -2,42 +2,118 @@ var app = require("../../app");
 const Favorite = require("../../models/favorite");
 
 describe("Favorite model", ()=> {
-  it("exists", ()=> {
-    const body = {
-      "id": 1,
-      "title": "We Will Rock You",
-      "artistName": "Queen",
-      "genre": "Rock",
-      "rating": 88
+  beforeEach(()=> {
+    body = {
+      "message": {
+        "header": {
+          "status_code": 200,
+          "execute_time": 0.010143041610718,
+          "confidence": 1000,
+          "mode": "search",
+          "cached": 1
+        },
+        "body": {
+          "track": {
+            "track_id": 161867099,
+            "track_name": "We Will Rock You",
+            "track_name_translation_list": [],
+            "track_rating": 79,
+            "commontrack_id": 92681952,
+            "instrumental": 0,
+            "explicit": 0,
+            "has_lyrics": 1,
+            "has_subtitles": 1,
+            "has_richsync": 1,
+            "num_favourite": 373,
+            "album_id": 30782812,
+            "album_name": "Greatest Hits",
+            "artist_id": 118,
+            "artist_name": "Queen",
+            "track_share_url": "https://www.musixmatch.com/lyrics/Queen/We-Will-Rock-You-1?utm_source=application&utm_campaign=api&utm_medium=Turing%3A1409618774628",
+            "track_edit_url": "https://www.musixmatch.com/lyrics/Queen/We-Will-Rock-You-1/edit?utm_source=application&utm_campaign=api&utm_medium=Turing%3A1409618774628",
+            "restricted": 0,
+            "updated_time": "2019-03-16T18:00:46Z",
+            "primary_genres": {
+              "music_genre_list": [
+                {
+                  "music_genre": {
+                    "music_genre_id": 1146,
+                    "music_genre_parent_id": 21,
+                    "music_genre_name": "Arena Rock",
+                    "music_genre_name_extended": "Rock / Arena Rock",
+                    "music_genre_vanity": "Rock-Arena-Rock"
+                  }
+                },
+                {
+                  "music_genre": {
+                    "music_genre_id": 21,
+                    "music_genre_parent_id": 34,
+                    "music_genre_name": "Rock",
+                    "music_genre_name_extended": "Rock",
+                    "music_genre_vanity": "Rock"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
     }
+  })
+
+  it("exists", ()=> {
     var fav = new Favorite(body);
     expect(fav).toBeInstanceOf(Favorite);
   })
 
   it("attributes", ()=> {
-    const body = {
-      "id": 1,
-      "title": "We Will Rock You",
-      "artistName": "Queen",
-      "genre": "Rock",
-      "rating": 88
-    }
     var fav = new Favorite(body);
 
-    expect(fav.title).toBe(body.title);
-    expect(fav.artist_name).toBe(body.artistName);
-    expect(fav.genre).toBe(body.genre);
-    expect(fav.rating).toBe(body.rating);
+    expect(fav.title).toBe("We Will Rock You");
+    expect(fav.artist_name).toBe("Queen");
+    expect(fav.genre).toBe("Arena Rock");
+    expect(fav.rating).toBe(79);
   })
 
   it("has default genre 'Unknown'", ()=> {
-    const body = {
-      "id": 1,
-      "title": "We Will Rock You",
-      "artistName": "Queen",
-      "rating": 88
+    const noGenres = {
+      "message": {
+        "header": {
+          "status_code": 200,
+          "execute_time": 0.010762929916382,
+          "confidence": 1000,
+          "mode": "search",
+          "cached": 1
+        },
+        "body": {
+          "track": {
+            "track_id": 161867099,
+            "track_name": "We Will Rock You",
+            "track_name_translation_list": [],
+            "track_rating": 79,
+            "commontrack_id": 92681952,
+            "instrumental": 0,
+            "explicit": 0,
+            "has_lyrics": 1,
+            "has_subtitles": 1,
+            "has_richsync": 1,
+            "num_favourite": 373,
+            "album_id": 30782812,
+            "album_name": "Greatest Hits",
+            "artist_id": 118,
+            "artist_name": "Queen",
+            "track_share_url": "https://www.musixmatch.com/lyrics/Queen/We-Will-Rock-You-1?utm_source=application&utm_campaign=api&utm_medium=Turing%3A1409618774628",
+            "track_edit_url": "https://www.musixmatch.com/lyrics/Queen/We-Will-Rock-You-1/edit?utm_source=application&utm_campaign=api&utm_medium=Turing%3A1409618774628",
+            "restricted": 0,
+            "updated_time": "2019-03-16T18:00:46Z",
+            "primary_genres": {
+              "music_genre_list": []
+            }
+          }
+        }
+      }
     }
-    var fav = new Favorite(body);
+    var fav = new Favorite(noGenres);
     expect(fav.genre).toBe("Unknown");
   })
 })

--- a/tests/services/musixService.spec.js
+++ b/tests/services/musixService.spec.js
@@ -1,0 +1,21 @@
+var app = require('../../app');
+const MusixService = require('../../services/musixService');
+
+describe("MusixService", ()=> {
+  it("can initialize", ()=> {
+    let service = new MusixService("We Will Rock You", "Queen");
+
+    expect(service).toBeInstanceOf(MusixService);
+  })
+
+  it("can fetch song details from musixmatch API", async ()=> {
+    let service = await new MusixService("We Will Rock You", "Queen");
+    let res = await service.fetchSongInfo();
+    
+    let track = res.message.body.track;
+    
+    expect(res).toHaveProperty("message");
+    expect(track).toHaveProperty("track_rating");
+    expect(track).toHaveProperty("primary_genres");
+  })
+})


### PR DESCRIPTION
### Summary
- Adds amended `POST /api/v1/favorites` endpoint that uses musixmatch API to obtain rating and genre attributes for songs.
- Adds `GET /api/v1/favorites/:id` endpoint that retrieves one favorite song by record id.