### PR TITLE
Refactor: Move async helper function to module

### DIFF
--- a/helpers/favoritesHelpers.js
+++ b/helpers/favoritesHelpers.js
@@ -13,9 +13,20 @@ async function favoriteSongs() {
 
 async function favoriteSong(songId) {
   try {
-    return await database('favorites').where({ id: songId })
+    return await database('favorites')
+      .where({ id: songId })
       .column(['id', 'title', 'artist_name', 'genre', 'rating'])
   } catch (e) {
+    return e;
+  }
+}
+
+async function createFavorite(fav) {
+  try {
+    return await database('favorites')
+      .insert(fav, 'id')
+      .returning(['id', 'title', 'artist_name', 'genre', 'rating'])
+  } catch(e) {
     return e;
   }
 }
@@ -31,5 +42,6 @@ async function seekAndDestroy(targetId) {
 module.exports = {
   favoriteSongs: favoriteSongs,
   favoriteSong: favoriteSong,
+  createFavorite: createFavorite,
   seekAndDestroy: seekAndDestroy
 }

--- a/helpers/favoritesHelpers.js
+++ b/helpers/favoritesHelpers.js
@@ -1,0 +1,35 @@
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+async function favoriteSongs() {
+  try {
+    return await database('favorites')
+      .column(['id', 'title', 'artist_name', 'genre', 'rating'])
+  } catch (e) {
+    return e;
+  }
+}
+
+async function favoriteSong(songId) {
+  try {
+    return await database('favorites').where({ id: songId })
+      .column(['id', 'title', 'artist_name', 'genre', 'rating'])
+  } catch (e) {
+    return e;
+  }
+}
+
+async function seekAndDestroy(targetId) {
+  try {
+    return await database('favorites').where({ id: targetId }).del()
+  } catch (e) {
+    return e;
+  }
+}
+
+module.exports = {
+  favoriteSongs: favoriteSongs,
+  favoriteSong: favoriteSong,
+  seekAndDestroy: seekAndDestroy
+}

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -10,6 +10,7 @@ const favoritesHelpers = require("../../../helpers/favoritesHelpers");
 const favoriteSongs = favoritesHelpers.favoriteSongs;
 const favoriteSong = favoritesHelpers.favoriteSong;
 const seekAndDestroy = favoritesHelpers.seekAndDestroy;
+const createFavorite = favoritesHelpers.createFavorite;
 
 router.get('/', (request, response) => {
   favoriteSongs()
@@ -56,13 +57,19 @@ router.post('/', (request, response) => {
   .then(res => {
     var fav = new Favorite(res);
 
-    database('favorites')
-      .insert(fav, 'id')
-      .returning(['id', 'title', 'artist_name', 'genre', 'rating'])
-      .then(attr => {
-        response.status(201).send(attr[0])
-      })
-      .catch(error => response.status(500).send({ error }))
+    createFavorite(fav)
+    .then(attr => {
+      response.status(201).send(attr[0])
+    })
+    .catch(error => response.status(500).send({ error }))
+
+    // database('favorites')
+    //   .insert(fav, 'id')
+    //   .returning(['id', 'title', 'artist_name', 'genre', 'rating'])
+    //   .then(attr => {
+    //     response.status(201).send(attr[0])
+    //   })
+    //   .catch(error => response.status(500).send({ error }))
   })
 });
 

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -1,9 +1,6 @@
 require('dotenv').config()
 var express = require('express');
 var router = express.Router();
-// const environment = process.env.NODE_ENV || 'development';
-// const configuration = require('../../../knexfile')[environment];
-// const database = require('knex')(configuration);
 const Favorite = require("../../../models/favorite");
 const MusixService = require("../../../services/musixService");
 const favoritesHelpers = require("../../../helpers/favoritesHelpers");
@@ -62,14 +59,6 @@ router.post('/', (request, response) => {
       response.status(201).send(attr[0])
     })
     .catch(error => response.status(500).send({ error }))
-
-    // database('favorites')
-    //   .insert(fav, 'id')
-    //   .returning(['id', 'title', 'artist_name', 'genre', 'rating'])
-    //   .then(attr => {
-    //     response.status(201).send(attr[0])
-    //   })
-    //   .catch(error => response.status(500).send({ error }))
   })
 });
 
@@ -87,31 +76,5 @@ router.delete('/:id', (request, response) => {
       }
     })
 });
-
-// async function favoriteSongs() {
-//   try{
-//     return await database('favorites')
-//     .column(['id', 'title', 'artist_name', 'genre', 'rating'])
-//   }catch(e){
-//     return e;
-//   }
-// }
-
-// async function favoriteSong(songId) {
-//   try{
-//     return await database('favorites').where({id: songId})
-//     .column(['id', 'title', 'artist_name', 'genre', 'rating'])
-//   }catch(e){
-//     return e;
-//   }
-// }
-
-// async function seekAndDestroy(targetId){
-//   try {
-//     return await database('favorites').where({id: targetId}).del()
-//   }catch(e){
-//     return e;
-//   }
-// }
 
 module.exports = router;

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -11,28 +11,30 @@ const createFavorite = favoritesHelpers.createFavorite;
 
 router.get('/', (request, response) => {
   favoriteSongs()
-    .then(favorites => {
-      if (favorites.length) {
-        response.status(200).send(favorites)
-      } else {
-        response.status(404).json({
-          error: 'Not found.'
-        })
-      }
-    })
+  .then(favorites => {
+    if (favorites.length) {
+      response.status(200).send(favorites)
+    } else {
+      response.status(404).json({
+        error: 'Not found.'
+      })
+    }
+  })
+  .catch(error => response.status(500).send({ error }))
 });
 
 router.get('/:id', (request, response) => {
   favoriteSong(request.params.id)
-    .then(favorite => {
-      if (favorite.length) {
-        response.status(200).send(favorite)
-      } else {
-        response.status(404).json({
-          error: 'Record not found.'
-        })
-      }
-    })
+  .then(favorite => {
+    if (favorite.length) {
+      response.status(200).send(favorite)
+    } else {
+      response.status(404).json({
+        error: 'Record not found.'
+      })
+    }
+  })
+  .catch(error => response.status(500).send({ error }))
 });
 
 router.post('/', (request, response) => {
@@ -60,21 +62,24 @@ router.post('/', (request, response) => {
     })
     .catch(error => response.status(500).send({ error }))
   })
+  .catch(error => response.status(500).send({ error }))
 });
 
 router.delete('/:id', (request, response) => {
   favoriteSong(request.params.id)
-    .then(favorite => {
-      if (favorite.length) {
-        let targetId = request.params.id
-        seekAndDestroy(targetId)
-        .then(() => response.status(204).send())
-      } else {
-        response.status(404).json({
-          error: 'Record not found.'
-        })
-      }
-    })
+  .then(favorite => {
+    if (favorite.length) {
+      let targetId = request.params.id
+      seekAndDestroy(targetId)
+      .then(() => response.status(204).send())
+      .catch(error => response.status(500).send({ error }))
+    } else {
+      response.status(404).json({
+        error: 'Record not found.'
+      })
+    }
+  })
+  .catch(error => response.status(500).send({ error }))
 });
 
 module.exports = router;

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -1,11 +1,15 @@
 require('dotenv').config()
 var express = require('express');
 var router = express.Router();
-const environment = process.env.NODE_ENV || 'development';
-const configuration = require('../../../knexfile')[environment];
-const database = require('knex')(configuration);
+// const environment = process.env.NODE_ENV || 'development';
+// const configuration = require('../../../knexfile')[environment];
+// const database = require('knex')(configuration);
 const Favorite = require("../../../models/favorite");
 const MusixService = require("../../../services/musixService");
+const favoritesHelpers = require("../../../helpers/favoritesHelpers");
+const favoriteSongs = favoritesHelpers.favoriteSongs;
+const favoriteSong = favoritesHelpers.favoriteSong;
+const seekAndDestroy = favoritesHelpers.seekAndDestroy;
 
 router.get('/', (request, response) => {
   favoriteSongs()
@@ -77,30 +81,30 @@ router.delete('/:id', (request, response) => {
     })
 });
 
-async function favoriteSongs() {
-  try{
-    return await database('favorites')
-    .column(['id', 'title', 'artist_name', 'genre', 'rating'])
-  }catch(e){
-    return e;
-  }
-}
+// async function favoriteSongs() {
+//   try{
+//     return await database('favorites')
+//     .column(['id', 'title', 'artist_name', 'genre', 'rating'])
+//   }catch(e){
+//     return e;
+//   }
+// }
 
-async function favoriteSong(songId) {
-  try{
-    return await database('favorites').where({id: songId})
-    .column(['id', 'title', 'artist_name', 'genre', 'rating'])
-  }catch(e){
-    return e;
-  }
-}
+// async function favoriteSong(songId) {
+//   try{
+//     return await database('favorites').where({id: songId})
+//     .column(['id', 'title', 'artist_name', 'genre', 'rating'])
+//   }catch(e){
+//     return e;
+//   }
+// }
 
-async function seekAndDestroy(targetId){
-  try {
-    return await database('favorites').where({id: targetId}).del()
-  }catch(e){
-    return e;
-  }
-}
+// async function seekAndDestroy(targetId){
+//   try {
+//     return await database('favorites').where({id: targetId}).del()
+//   }catch(e){
+//     return e;
+//   }
+// }
 
 module.exports = router;


### PR DESCRIPTION
### Summary
- Moves all database async functions from routes file to favoritesHelpers, including:
    - `favoriteSongs()`
    - `favoriteSong()`
    - `seekAndDestroy()`

- Adds new helper function `createFavorite()` from logic that was in `POST /api/v1/favorites`
- Adds catch for 500 errors for all `.then` functions in favorites routes

