### PR TITLE
Fix bug from deletion of .json() from musixService

### DIFF
--- a/tests/services/musixService.spec.js
+++ b/tests/services/musixService.spec.js
@@ -1,8 +1,13 @@
 var app = require('../../app');
 const fetchSongInfo = require('../../utils/musixService');
+const songJson = require('../../tests/fixtures/queenSong');
 
-describe("MusixService", ()=> {
-  it("can fetch song details from musixmatch API", async ()=> {
+describe("MusixService", () => {
+  it("can fetch song details from musixmatch API", async () => {
+    fetch = jest.fn().mockImplementation(() => {
+      return Promise.resolve(songJson);
+    })
+
     let res = await fetchSongInfo("We Will Rock You", "Queen");
     let track = res.message.body.track;
     

--- a/utils/__mocks__/node-fetch.js
+++ b/utils/__mocks__/node-fetch.js
@@ -1,6 +1,0 @@
-const songJson = require('../../tests/fixtures/queenSong');
-
-const fetch = async function(url) {
-  return Promise.resolve(songJson);
-}
-module.exports = fetch;

--- a/utils/musixService.js
+++ b/utils/musixService.js
@@ -8,7 +8,7 @@ const fetchSongInfo = async function(title, artist) {
       `&q_artist=${artist}` +
       `&apikey=${key}`;
     let res = await fetch(url);
-    return res;
+    return res.json();
   } catch(e) {
     return e;
   }


### PR DESCRIPTION
### Summary
- `.json()` function was deleted in order to make musixService test pass, however, that was a vital piece of functionality in order to successfully create favorites records.
    - Adds `.json()` function back.
    - Tested POST in local server and it functions correctly.
- Deletes node-fetch mock file and moves mock logic to musixService.
