### PR TITLE
Fix favoritesHelpers spec to pass Travis build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "test": "jest --config ./jest.config.js --forceExit --coverage --runInBand"
+    "test": "jest --config ./jest.config.js --forceExit --coverage --runInBand --detectOpenHandles"
   },
   "dependencies": {
     "cookie-parser": "~1.4.4",

--- a/tests/utils/favoritesHelpers.spec.js
+++ b/tests/utils/favoritesHelpers.spec.js
@@ -7,7 +7,6 @@ const favoriteSong = helpers.favoriteSong;
 const createFavorite = helpers.createFavorite;
 const seekAndDestroy = helpers.seekAndDestroy;
 
-jest.mock('../../utils/musixService');
 
 describe('favoritesHelpers functions', () => {
   beforeEach(async () => {
@@ -25,8 +24,7 @@ describe('favoritesHelpers functions', () => {
 
   afterEach(async () => {
     await database.raw('TRUNCATE TABLE favorites CASCADE');
-    setTimeout(() => process.exit(), 2000);
-  });
+  })
 
   describe('favoriteSongs', () => {
     it('returns a list of all favorite songs', async () => {
@@ -55,6 +53,7 @@ describe('favoritesHelpers functions', () => {
   describe('createFavorite', () => {
     it('creates a new favorite in the database', async () => {
       var fave = {
+        id: 3,
         title: 'We Will Rock You',
         artist_name: 'Queen',
         genre: 'Arena Rock',
@@ -62,6 +61,7 @@ describe('favoritesHelpers functions', () => {
       };
 
       const newFavorite = await createFavorite(fave)
+
       expect(newFavorite[0].title).toBe('We Will Rock You');
       expect(newFavorite[0].artist_name).toBe('Queen');
       expect(newFavorite[0].genre).toBe('Arena Rock');

--- a/tests/utils/favoritesHelpers.spec.js
+++ b/tests/utils/favoritesHelpers.spec.js
@@ -25,9 +25,8 @@ describe('favoritesHelpers functions', () => {
 
   afterEach(async () => {
     await database.raw('TRUNCATE TABLE favorites CASCADE');
+    setTimeout(() => process.exit(), 2000);
   });
-
-  afterAll(() => setTimeout(() => process.exit(), 1000))
 
   describe('favoriteSongs', () => {
     it('returns a list of all favorite songs', async () => {


### PR DESCRIPTION
### Summary
- Without passing a unique id on line 63 of favoritesHelpers.spec.js, the test was passing locally but not in Travis virtual environment since it presumably tried to create a new record with id 1, which was already taken.

- This PR fixes the bug by explicitly passing an id with the object to `createFavorite()` function.
- Preliminary build passed, and this PR can be merged if the build passes here.