### PR TITLE
DELETE /playlists/:id/favorites/:id deletes all favorites #73

### DIFF
--- a/routes/api/v1/playlistFavorites.js
+++ b/routes/api/v1/playlistFavorites.js
@@ -26,14 +26,14 @@ router.post('/:favId', async (request, response) => {
 })
 
 router.delete('/:favId', async (request, response) => {
-  findPlaylist(request.params.playlistId)
+  const favId = request.params.favId
+  const playlistId = request.params.playlistId
+  findPlaylist(playlistId)
   .then(info => {
     if (info) {
-      findFavorite(request.params.favId)
+      findFavorite(favId)
       .then(data => {
         if (data) {
-          let favId = request.params.favId
-          let playlistId = request.params.playlistId
           deletePlaylistFavorite(playlistId, favId)
           .then(() => response.status(204).send())
         } else {

--- a/routes/api/v1/playlistFavorites.js
+++ b/routes/api/v1/playlistFavorites.js
@@ -32,8 +32,9 @@ router.delete('/:favId', async (request, response) => {
       findFavorite(request.params.favId)
       .then(data => {
         if (data) {
-          let targetId = request.params.favId
-          deletePlaylistFavorite(targetId)
+          let favId = request.params.favId
+          let playlistId = request.params.playlistId
+          deletePlaylistFavorite(playlistId, favId)
           .then(() => response.status(204).send())
         } else {
           response.status(404).json({

--- a/tests/playlistFavorites/destroy.spec.js
+++ b/tests/playlistFavorites/destroy.spec.js
@@ -29,11 +29,17 @@ describe("DELETE /api/v1/playlists/:id/favorites/:id", () => {
     await database('playlists')
       .insert({ id: 1, title: 'Focus On the Task' })
 
+    await database('playlists')
+      .insert({ id: 2, title: 'Sample Playlist' })
+
     await database('playlist_favorites')
       .insert({ id: 1, playlist_id: 1, favorite_id: 1})
 
     await database('playlist_favorites')
-      .insert({ id: 2, playlist_id: 1, favorite_id: 2})
+      .insert({ id: 2, playlist_id: 2, favorite_id: 1})
+
+    await database('playlist_favorites')
+      .insert({ id: 3, playlist_id: 2, favorite_id: 2})
 
     var response = await request(app)
       .delete('/api/v1/playlists/1/favorites/1')

--- a/tests/playlistFavorites/destroy.spec.js
+++ b/tests/playlistFavorites/destroy.spec.js
@@ -45,10 +45,17 @@ describe("DELETE /api/v1/playlists/:id/favorites/:id", () => {
       .delete('/api/v1/playlists/1/favorites/1')
 
     expect(response.status).toBe(204)
+
+    let result = await database('playlist_favorites')
+    .select('*')
+
+    expect(result).toEqual([
+      { id: 2, playlist_id: 2, favorite_id: 1 },
+      { id: 3, playlist_id: 2, favorite_id: 2 }
+    ])
   });
 
   it("returns a 404 if id is not found", async () => {
-
     var response = await request(app)
     .delete('/api/v1/playlists/1/favorites/1')
 

--- a/utils/playlistFavoritesHelpers.js
+++ b/utils/playlistFavoritesHelpers.js
@@ -13,9 +13,11 @@ const createPlaylistFavorite = async function(playlistId, favoriteId) {
   }
 }
 
-const deletePlaylistFavorite = async function seekAndDestroy(playlistId, favId) {
+async function deletePlaylistFavorite(playlistId, favId) {
   try {
-    return await database('playlist_favorites').where({ playlist_id: playlistId, favorite_id: favId }).del()
+    return await database('playlist_favorites')
+      .where({ playlist_id: playlistId, favorite_id: favId })
+      .del()
   } catch (e) {
     return e;
   }

--- a/utils/playlistFavoritesHelpers.js
+++ b/utils/playlistFavoritesHelpers.js
@@ -13,9 +13,9 @@ const createPlaylistFavorite = async function(playlistId, favoriteId) {
   }
 }
 
-const deletePlaylistFavorite = async function seekAndDestroy(targetId) {
+const deletePlaylistFavorite = async function seekAndDestroy(playlistId, favId) {
   try {
-    return await database('playlist_favorites').where({ favorite_id: targetId }).del()
+    return await database('playlist_favorites').where({ playlist_id: playlistId, favorite_id: favId }).del()
   } catch (e) {
     return e;
   }


### PR DESCRIPTION
This PR fixes the bug that was previously deleting all playlist_favorites that shared a single favorite. 