### PR TITLE
Bug: POST /playlists/:id/favorites/:id can create multiple records

### DIFF
--- a/tests/playlistFavorites/create.spec.js
+++ b/tests/playlistFavorites/create.spec.js
@@ -48,4 +48,17 @@ describe('POST /api/v1/playlists/:id/favorites/:id', () => {
     expect(res.status).toBe(400)
     expect(res.body).toEqual({ error: 'Could not create record with playlist_id: 1, favorite_id: 2' })
   })
+
+  it("sad path: returns 409 if favorite already exists", async () => {
+    await database('playlist_favorites')
+      .insert({ playlist_id: 1, favorite_id: 1 });
+    
+    const res = await request(app)
+      .post('/api/v1/playlists/1/favorites/1');
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      "error": "Record already exists with playlist_id: 1, favorite_id: 1"
+    })
+  })
 })


### PR DESCRIPTION
### Current Bug
- Sending multiple requests with the same parameters can create multiple records
#### Example: 
`POST /api/v1/playlists/5/favorites/10` 5 times creates:
![image](https://user-images.githubusercontent.com/18686466/70494654-57158c00-1ac9-11ea-8703-fdab0a800ec1.png)

### Fix
- Add logic to the endpoint to first check if the record with the request params already exists. 
- If it does not exist, create the new record
- If it exists, return: 
```
Status: 409
{
  "error": "Record already exists with playlist_id: 5, favorite_id: 10"
}
```
