### PR TITLE
To Dev: V2 delete favorite

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,12 +31,26 @@ app.use('/api/v1/playlists/:playlistId/favorites', playlistFavoritesRouter);
 const graphqlHTTP = require('express-graphql');
 const schema = require('./schema/schemaBuilder');
 const root = require('./schema/resolvers')
+const FormatError = require('easygraphql-format-error');
+
+const formatError = new FormatError([
+  {
+    name: 'FAVORITE_NOT_FOUND',
+    message: 'Record not found with provided ID.',
+    statusCode: 404
+  }
+])
+const errorName = formatError.errorName
 
 app.use('/api/v2/graphql', (req, res) => {
   graphqlHTTP({
     schema: schema,
     rootValue: root,
-    graphiql: true
+    graphiql: true,
+    context: { errorName },
+    customFormatErrorFn: (err) => {
+      return formatError.getError(err)
+    }
   })(req, res)
 })
 

--- a/app.js
+++ b/app.js
@@ -31,15 +31,7 @@ app.use('/api/v1/playlists/:playlistId/favorites', playlistFavoritesRouter);
 const graphqlHTTP = require('express-graphql');
 const schema = require('./schema/schemaBuilder');
 const root = require('./schema/resolvers')
-const FormatError = require('easygraphql-format-error');
-
-const formatError = new FormatError([
-  {
-    name: 'FAVORITE_NOT_FOUND',
-    message: 'Record not found with provided ID.',
-    statusCode: 404
-  }
-])
+const formatError = require('./utils/customErrors')
 const errorName = formatError.errorName
 
 app.use('/api/v2/graphql', (req, res) => {

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -6,7 +6,7 @@ const fetchSongInfo = require("../../../utils/musixService");
 const favoritesHelpers = require("../../../utils/favoritesHelpers");
 const favoriteSongs = favoritesHelpers.favoriteSongs;
 const favoriteSong = favoritesHelpers.favoriteSong;
-const seekAndDestroy = favoritesHelpers.seekAndDestroy;
+const destroyFavorite = favoritesHelpers.destroyFavorite;
 const createFavorite = favoritesHelpers.createFavorite;
 
 router.get('/', (request, response) => {
@@ -71,7 +71,7 @@ router.delete('/:id', (request, response) => {
   .then(favorite => {
     if (favorite) {
       let targetId = request.params.id
-      seekAndDestroy(targetId)
+      destroyFavorite(targetId)
       .then(() => response.status(204).send())
       .catch(error => response.status(500).send({ error }))
     } else {

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -1,11 +1,21 @@
-const fetchSongInfo = require('../utils/musixService')
-const Favorite = require('../models/favorite')
+const fetchSongInfo = require('../utils/musixService');
+const Favorite = require('../models/favorite');
+// const FormatError = require('easygraphql-format-error');
 const {
   favoriteSongs,
   favoriteSong,
   createFavorite,
   destroyFavorite
-} = require('../utils/favoritesHelpers')
+} = require('../utils/favoritesHelpers');
+
+// const favNotFoundError = new FormatError([
+//   {
+//     name: 'FAVORITE_NOT_FOUND',
+//     message: 'Record not found with provided ID.',
+//     statusCode: 404
+//   }
+// ])
+// const errorName = favNotFoundError.errorName
 
 const resolvers = {
   favorites: () => {
@@ -22,9 +32,13 @@ const resolvers = {
       return newFavorite;
     }
   },
-  deleteFavorite: async (args) => {
-    let result = await destroyFavorite(args.id)
-    return `Deleted favorite with id: ${result}`
+  deleteFavorite: async (args, { errorName }) => {
+    let result = await destroyFavorite(args.id);
+    if (result === 0) {
+      throw new Error(errorName.FAVORITE_NOT_FOUND);
+    } else {
+      return `Deleted favorite with id: ${result}`;
+    }
   }
 };
 

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -35,7 +35,7 @@ const resolvers = {
     if (result === 0) {
       throw new Error(errorName.FAVORITE_NOT_FOUND);
     }
-    return `Deleted favorite with id: ${result}`;
+    return `Deleted favorite with id: ${args.id}`;
   }
 };
 

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -3,7 +3,8 @@ const Favorite = require('../models/favorite')
 const {
   favoriteSongs,
   favoriteSong,
-  createFavorite
+  createFavorite,
+  destroyFavorite
 } = require('../utils/favoritesHelpers')
 
 const resolvers = {
@@ -20,6 +21,10 @@ const resolvers = {
       let newFavorite = await createFavorite(fav);
       return newFavorite;
     }
+  },
+  deleteFavorite: async (args) => {
+    let result = await destroyFavorite(args.id)
+    return `Deleted favorite with id: ${result}`
   }
 };
 

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -20,13 +20,14 @@ const resolvers = {
     return result
   },
 
-  createFavorite: async (args) => {
+  createFavorite: async (args, { errorName }) => {
     const data = await fetchSongInfo(args.title, args.artistName);
-    if (data.message.body) {
-      const fav = new Favorite(data);
-      const newFavorite = await createFavorite(fav);
-      return newFavorite;
+    if (!data.message.body) {
+      throw new Error(errorName.EMPTY_SONG_DATA)
     }
+    const fav = new Favorite(data);
+    const newFavorite = await createFavorite(fav);
+    return newFavorite;
   },
 
   deleteFavorite: async (args, { errorName }) => {

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -12,26 +12,29 @@ const resolvers = {
     return favoriteSongs();
   },
 
-  favorite: (args) => {
-    return favoriteSong(args.id);
+  favorite: async (args, { errorName }) => {
+    const result = await favoriteSong(args.id);
+    if (result === undefined) {
+      throw new Error(errorName.FAVORITE_NOT_FOUND)
+    }
+    return result
   },
 
   createFavorite: async (args) => {
     const data = await fetchSongInfo(args.title, args.artistName);
     if (data.message.body) {
-      let fav = new Favorite(data);
-      let newFavorite = await createFavorite(fav);
+      const fav = new Favorite(data);
+      const newFavorite = await createFavorite(fav);
       return newFavorite;
     }
   },
-  
+
   deleteFavorite: async (args, { errorName }) => {
-    let result = await destroyFavorite(args.id);
+    const result = await destroyFavorite(args.id);
     if (result === 0) {
       throw new Error(errorName.FAVORITE_NOT_FOUND);
-    } else {
-      return `Deleted favorite with id: ${result}`;
     }
+    return `Deleted favorite with id: ${result}`;
   }
 };
 

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -1,21 +1,11 @@
 const fetchSongInfo = require('../utils/musixService');
 const Favorite = require('../models/favorite');
-// const FormatError = require('easygraphql-format-error');
 const {
   favoriteSongs,
   favoriteSong,
   createFavorite,
   destroyFavorite
 } = require('../utils/favoritesHelpers');
-
-// const favNotFoundError = new FormatError([
-//   {
-//     name: 'FAVORITE_NOT_FOUND',
-//     message: 'Record not found with provided ID.',
-//     statusCode: 404
-//   }
-// ])
-// const errorName = favNotFoundError.errorName
 
 const resolvers = {
   favorites: () => {

--- a/schema/resolvers.js
+++ b/schema/resolvers.js
@@ -11,9 +11,11 @@ const resolvers = {
   favorites: () => {
     return favoriteSongs();
   },
+
   favorite: (args) => {
     return favoriteSong(args.id);
   },
+
   createFavorite: async (args) => {
     const data = await fetchSongInfo(args.title, args.artistName);
     if (data.message.body) {
@@ -22,6 +24,7 @@ const resolvers = {
       return newFavorite;
     }
   },
+  
   deleteFavorite: async (args, { errorName }) => {
     let result = await destroyFavorite(args.id);
     if (result === 0) {

--- a/schema/schema/schema.gql
+++ b/schema/schema/schema.gql
@@ -13,4 +13,5 @@ type Query {
 
 type Mutation {
   createFavorite(title: String!, artistName: String!): Favorite
+  deleteFavorite(id: ID!): String!
 }

--- a/tests/requests/v2/favorites/create.spec.js
+++ b/tests/requests/v2/favorites/create.spec.js
@@ -88,4 +88,15 @@ describe("Test /api/v2/graphql mutation createFavorite", () => {
     const errorMessage2 = res2.body.errors[0].message
     expect(errorMessage2).toBe('Field "createFavorite" argument "artistName" of type "String!" is required, but it was not provided.')
   })
+
+  it('sad path: fetchSongInfo does not find song', async () => {
+    const mutation = 'mutation{createFavorite(title: "askjdfakjf", artistName: "asjdfhajsdf")' +
+      '{title artist_name rating genre}}';
+    const res = await request(app)
+      .post(`/api/v2/graphql?query=${mutation}`);
+
+    const errorMessage = res.body.errors[0];
+    expect(errorMessage.statusCode).toBe(400);
+    expect(errorMessage.message).toBe("Could not fetch song data with given 'title' and 'artistName'.");
+  })
 })

--- a/tests/requests/v2/favorites/delete.spec.js
+++ b/tests/requests/v2/favorites/delete.spec.js
@@ -1,0 +1,44 @@
+var request = require("supertest");
+var app = require('../../../../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../../../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe("Test /api/v2/graphql mutation deleteFavorite", () => {
+  beforeEach(async () => {
+    await database.raw("TRUNCATE TABLE playlist_favorites CASCADE");
+    await database.raw("TRUNCATE TABLE playlists CASCADE");
+    await database.raw("TRUNCATE TABLE favorites CASCADE");
+  });
+
+  afterEach(async () => {
+    await database.raw("TRUNCATE TABLE playlist_favorites CASCADE");
+    await database.raw("TRUNCATE TABLE playlists CASCADE");
+    await database.raw("TRUNCATE TABLE favorites CASCADE");
+  });
+
+  it.only("deletes a single favorite by id", async () => {
+
+    await database('favorites')
+      .insert({ id: 1, title: 'Thunderstruck', artist_name: 'AC/DC', genre: 'Rock', rating: 98 });
+
+    var favorites = await database('favorites');
+    expect(favorites.length).toBe(1);
+
+    const query = 'mutation{deleteFavorite(id: 1){id title}}'
+    const response = await request(app)
+      .post(`/api/v2/graphql?query=${query}`);
+
+    favorites = await database('favorites');
+    expect(favorites.length).toBe(0);
+
+    console.log(response.body)
+    expect(response.status).toBe(200);
+  });
+
+  it("returns null data if id is not found", async () => {
+    // expect(response.status).toBe(404)
+    // expect(response.body.error).toBe('Record not found.')
+  });
+});

--- a/tests/requests/v2/favorites/delete.spec.js
+++ b/tests/requests/v2/favorites/delete.spec.js
@@ -38,7 +38,7 @@ describe("Test /api/v2/graphql mutation deleteFavorite", () => {
     expect(response.body).toEqual(expected);
   });
 
-  it("returns null data if id is not found", async () => {
+  it("returns custom error if id is not found", async () => {
     const query = 'mutation{deleteFavorite(id: 100)}'
     const response = await request(app)
       .post(`/api/v2/graphql?query=${query}`);

--- a/tests/requests/v2/favorites/delete.spec.js
+++ b/tests/requests/v2/favorites/delete.spec.js
@@ -26,15 +26,16 @@ describe("Test /api/v2/graphql mutation deleteFavorite", () => {
     var favorites = await database('favorites');
     expect(favorites.length).toBe(1);
 
-    const query = 'mutation{deleteFavorite(id: 1){id title}}'
+    const query = 'mutation{deleteFavorite(id: 1)}'
     const response = await request(app)
       .post(`/api/v2/graphql?query=${query}`);
 
     favorites = await database('favorites');
     expect(favorites.length).toBe(0);
 
-    console.log(response.body)
+    const expected = { data: { deleteFavorite: 'Deleted favorite with id: 1' } }
     expect(response.status).toBe(200);
+    expect(response.body).toEqual(expected);
   });
 
   it("returns null data if id is not found", async () => {

--- a/tests/requests/v2/favorites/delete.spec.js
+++ b/tests/requests/v2/favorites/delete.spec.js
@@ -18,7 +18,7 @@ describe("Test /api/v2/graphql mutation deleteFavorite", () => {
     await database.raw("TRUNCATE TABLE favorites CASCADE");
   });
 
-  it.only("deletes a single favorite by id", async () => {
+  it("deletes a single favorite by id", async () => {
 
     await database('favorites')
       .insert({ id: 1, title: 'Thunderstruck', artist_name: 'AC/DC', genre: 'Rock', rating: 98 });
@@ -39,7 +39,12 @@ describe("Test /api/v2/graphql mutation deleteFavorite", () => {
   });
 
   it("returns null data if id is not found", async () => {
-    // expect(response.status).toBe(404)
-    // expect(response.body.error).toBe('Record not found.')
+    const query = 'mutation{deleteFavorite(id: 100)}'
+    const response = await request(app)
+      .post(`/api/v2/graphql?query=${query}`);
+
+    const errorMessage = response.body.errors[0];
+    expect(errorMessage.statusCode).toBe(404);
+    expect(errorMessage.message).toBe("Record not found with provided ID.");
   });
 });

--- a/tests/requests/v2/favorites/show.spec.js
+++ b/tests/requests/v2/favorites/show.spec.js
@@ -51,12 +51,14 @@ describe("Test /api/v2/graphql query favorite", () => {
     expect(response2.body).toEqual(expected2)
   });
 
-  it.skip("returns a 404 if id is not found", async () => {
+  it("returns custom error if id is not found", async () => {
     const query = 'query{favorite(id: 100){id title artist_name genre rating}}'
     const response = await request(app)
       .post(`/api/v2/graphql?query=${query}`)
 
-    // expect(response.status).toBe(404)
-    expect(response.body).toEqual({ error: 'Favorite with id: 100 not found.' })
+    const errorMessage = response.body.errors[0];
+
+    expect(errorMessage.statusCode).toBe(404);
+    expect(errorMessage.message).toBe("Record not found with provided ID.");
   });
 });

--- a/tests/utils/favoritesHelpers.spec.js
+++ b/tests/utils/favoritesHelpers.spec.js
@@ -5,7 +5,7 @@ const helpers = require('../../utils/favoritesHelpers');
 const favoriteSongs = helpers.favoriteSongs;
 const favoriteSong = helpers.favoriteSong;
 const createFavorite = helpers.createFavorite;
-const seekAndDestroy = helpers.seekAndDestroy;
+const destroyFavorite = helpers.destroyFavorite;
 
 
 describe('favoritesHelpers functions', () => {
@@ -18,7 +18,7 @@ describe('favoritesHelpers functions', () => {
 
     let fave2 = await database('favorites')
       .insert({id: 2, title: 'Africa', artist_name: 'Toto', genre: 'pop', rating: 100})
-    .returning(['id', 'title', 'artist_name', 'genre', 'rating'])
+      .returning(['id', 'title', 'artist_name', 'genre', 'rating'])
 
   });
 
@@ -29,6 +29,7 @@ describe('favoritesHelpers functions', () => {
   describe('favoriteSongs', () => {
     it('returns a list of all favorite songs', async () => {
       const favorites = await favoriteSongs();
+      expect(favorites.length).toBe(2);
       expect(favorites[0].id).toBe(1);
       expect(favorites[0].title).toBe('Thunderstruck');
       expect(favorites[0].artist_name).toBe('AC/DC');
@@ -46,7 +47,6 @@ describe('favoritesHelpers functions', () => {
       expect(favorite.artist_name).toBe('Toto');
       expect(favorite.genre).toBe('pop');
       expect(favorite.rating).toBe(100);
-      expect(favorite[1]).toBeUndefined()
     })
   })
 
@@ -66,11 +66,10 @@ describe('favoritesHelpers functions', () => {
       expect(newFavorite.artist_name).toBe('Queen');
       expect(newFavorite.genre).toBe('Arena Rock');
       expect(newFavorite.rating).toBe(78);
-      expect(newFavorite[1]).toBeUndefined()
     })
   })
 
-  describe('seekAndDestroy', () => {
+  describe('destroyFavorite', () => {
     it('deletes a favorite from the database', async() => {
       var favorites = await favoriteSongs();
       expect(favorites[0].id).toBe(1);
@@ -80,7 +79,8 @@ describe('favoritesHelpers functions', () => {
       expect(favorites[0].rating).toBe(98);
       expect(favorites[1].title).toBe('Africa')
 
-      await seekAndDestroy(1)
+      let res = await destroyFavorite(1)
+      console.log(res)
       var postDestroyFavorites = await favoriteSongs()
 
       expect(postDestroyFavorites[0].id).toBe(2);

--- a/tests/utils/favoritesHelpers.spec.js
+++ b/tests/utils/favoritesHelpers.spec.js
@@ -79,8 +79,7 @@ describe('favoritesHelpers functions', () => {
       expect(favorites[0].rating).toBe(98);
       expect(favorites[1].title).toBe('Africa')
 
-      let res = await destroyFavorite(1)
-      console.log(res)
+      await destroyFavorite(1)
       var postDestroyFavorites = await favoriteSongs()
 
       expect(postDestroyFavorites[0].id).toBe(2);

--- a/utils/customErrors.js
+++ b/utils/customErrors.js
@@ -5,6 +5,11 @@ const formatError = new FormatError([
     name: 'FAVORITE_NOT_FOUND',
     message: 'Record not found with provided ID.',
     statusCode: 404
+  },
+  {
+    name: 'EMPTY_SONG_DATA',
+    message: "Could not fetch song data with given 'title' and 'artistName'.",
+    statusCode: 400
   }
 ])
 

--- a/utils/customErrors.js
+++ b/utils/customErrors.js
@@ -1,0 +1,11 @@
+const FormatError = require('easygraphql-format-error');
+
+const formatError = new FormatError([
+  {
+    name: 'FAVORITE_NOT_FOUND',
+    message: 'Record not found with provided ID.',
+    statusCode: 404
+  }
+])
+
+module.exports = formatError;

--- a/utils/favoritesHelpers.js
+++ b/utils/favoritesHelpers.js
@@ -33,7 +33,7 @@ async function createFavorite(fav) {
   }
 }
 
-async function seekAndDestroy(targetId) {
+async function destroyFavorite(targetId) {
   try {
     return await database('favorites').where({ id: targetId }).del()
   } catch (e) {
@@ -45,5 +45,5 @@ module.exports = {
   favoriteSongs: favoriteSongs,
   favoriteSong: favoriteSong,
   createFavorite: createFavorite,
-  seekAndDestroy: seekAndDestroy
+  destroyFavorite: destroyFavorite
 }


### PR DESCRIPTION
- A user can send a request to delete a favorite with the following mutation query, where `ID!` can be an integer or a string of an integer:
### Example query:
```
mutation {
   deleteFavorite(id: ID!)
}
```

### Success Response:
```json
{
  "data": {
    "deleteFavorite": "Deleted favorite with id: 37"
  }
}
```
### Error responses:
#### record not found
```json
{
  "errors": [
    {
      "message": "Record not found with provided ID.",
      "statusCode": 404
    }
  ],
  "data": null
}
```
#### missing required ID argument:
```json
{
  "errors": [
    {
      "message": "Field \"deleteFavorite\" argument \"id\" of type \"ID!\" is required, but it was not provided.",
      "locations": [
        {
          "line": 2,
          "column": 4
        }
      ]
    }
  ]
}
```
### Additional Notes:
- Add custom error handling for FAVORITE_NOT_FOUND to `deleteFavorite` mutation, and `favorite` query
- Add custom error handling for EMPTY_SONG_DATA to `createFavorite` mutation.